### PR TITLE
Add option to redirect reddit.com to old.reddit.com

### DIFF
--- a/background.js
+++ b/background.js
@@ -30,9 +30,67 @@ function setCookie() {
     }, onError);
 }
 
+function toggleRedirect(doRedirect) {
+    if (doRedirect) {
+        browser.webRequest.onBeforeRequest.addListener(
+            redirect,
+            {
+                urls: [
+                    'https://www.reddit.com/*',
+                    'https://reddit.com/*',
+                    'http://www.reddit.com/*',
+                    'http://reddit.com/*'
+                ]
+            },
+            [ 'blocking' ]);
+
+        // flush in-memory cache to prevent fetchs from cache w/o redirect
+        browser.webRequest.handlerBehaviorChanged()
+            .then(() => { console.log('In-memory cache flush'); }, onError);
+    } else {
+        const requestedPermissions = {
+            permissions: [ 'webRequest', 'webRequestBlocking' ]
+        };
+        browser.permissions.contains(requestedPermissions)
+            .then((result) => {
+                if (result) {
+                    if (browser.webRequest.onBeforeRequest.hasListener(redirect)) {
+                        browser.webRequest.onBeforeRequest.removeListener(redirect);
+                    }
+                    // revoke webRequest permissions
+                    browser.permissions.remove(requestedPermissions)
+                        .then((result) => {
+                            result
+                                ? console.log('Permissions revoked')
+                                : console.error('Permissions revoke error');
+                        }, onError);
+                }}, onError);
+    }
+}
+
+/**
+ * Listener to redirect www.reddit.com requests to old.reddit.com
+ */
+function redirect(request) {
+    console.log(request.url);
+    const redirectUrl = request.url.replace(
+        /^(?:https|http):\/\/(?:www\.)?reddit\.com/,
+        'https://old.reddit.com');
+    return Promise.resolve({ redirectUrl });
+}
+
 (function () {
     // set the cookie on profile/extension load and for every new tab
     browser.runtime.onInstalled.addListener(setCookie);
     browser.runtime.onStartup.addListener(setCookie);
     browser.tabs.onCreated.addListener(setCookie);
+
+    // check if redirecting is enabled, default to false
+    browser.storage.local.get({ redirect: false })
+        .then((obj) => { toggleRedirect(obj.redirect); }, onError);
+
+    // enable/disable redirect on storage change
+    browser.storage.onChanged.addListener((changes) => {
+        toggleRedirect(changes.redirect.newValue);
+    });
 })();

--- a/background.js
+++ b/background.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // set this cookie to make Reddit not show the mobile site on mobile devices
 const noMobileCookie = {
     url: "https://.reddit.com",
@@ -91,6 +93,20 @@ function redirect(request) {
 
     // enable/disable redirect on storage change
     browser.storage.onChanged.addListener((changes) => {
-        toggleRedirect(changes.redirect.newValue);
+        if ('redirect' in changes) {
+            if (changes.redirect.oldValue !== changes.redirect.newValue) {
+                toggleRedirect(changes.redirect.newValue);
+            }
+        }
     });
+
+    // open preference page onInstall, once
+    browser.runtime.onInstalled.addListener(() => {
+        browser.storage.local.get({ firstInstall: true })
+            .then((obj) => {
+                if (obj.firstInstall) return browser.runtime.openOptionsPage();
+            }).then(() => {
+                return browser.storage.local.set({ firstInstall: false });
+            }).then(() => { return browser.storage.local.get(); })
+            .then((obj) => { console.log(obj); }, onError)});
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -9,12 +9,16 @@
     },
     "permissions": [
         "*://*.reddit.com/",
-        "cookies"
+        "cookies",
+        "storage"
     ],
     "background": {
         "scripts": [
             "background.js"
         ]
+    },
+    "options_ui": {
+        "page": "options/options.html"
     },
     "applications": {
         "gecko": {

--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,10 @@
         "cookies",
         "storage"
     ],
+    "optional_permissions": [
+        "webRequest",
+        "webRequestBlocking"
+    ],
     "background": {
         "scripts": [
             "background.js"
@@ -23,7 +27,7 @@
     "applications": {
         "gecko": {
             "id": "nomobilereddit@tossj.addons.mozilla.org",
-            "strict_min_version": "54.0"
+            "strict_min_version": "55.0"
         }
     },
     "short_name": "NMR"

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
         ]
     },
     "options_ui": {
-        "page": "options/options.html"
+        "page": "options/options.html",
+        "browser_style": true
     },
     "applications": {
         "gecko": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "No mobile reddit",
-    "version": "1.0",
+    "version": "1.1",
     "description": "Prevents the mobile-friendly version of reddit from loading in the browser.",
     "icons": {
         "48": "no-mobile-reddit.svg",

--- a/options/open-in-new.svg
+++ b/options/open-in-new.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<!-- fill changed to #0060df -->
+<!-- Icon from https://design.firefox.com/icons/viewer/#open -->
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M7 5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-1a1 1 0 1 1 2 0v1a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V7a4 4 0 0 1 4-4h1a1 1 0 0 1 0 2H7zm6 0a1 1 0 1 1 0-2h7a1 1 0 0 1 1 1v7a1 1 0 1 1-2 0V6.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L17.586 5H13z" fill="#0060df" fill-opacity=".8"></path></svg>

--- a/options/options.css
+++ b/options/options.css
@@ -1,0 +1,51 @@
+.helper {
+    font-size: 15px;
+    color: #737373;
+    padding-left: 24px;
+    margin-top: 8px;
+}
+
+a {
+    text-decoration: none;
+    color: #0060df;
+}
+
+a:hover {
+    color: #0060df;
+    text-decoration: underline;
+}
+
+a:active {
+    color: #003eaa;
+    text-decoration: underline;
+}
+
+a:focus {
+    box-shadow: 0 0 0 2px #0a84ff, 0 0 0 6px rgba(10, 132, 255, 0.3);
+}
+
+.external-link::after {
+    content: "";
+    background-image: url("./open-in-new.svg");
+    background-repeat: no-repeat;
+    vertical-align: middle;
+    background-size: 16px 16px;
+    fill: #0060df;
+    height: 16px;
+    width: 16px;
+    display: inline-block;
+    margin: 0px 2px;
+}
+
+label {
+    font-size: 15px;
+}
+
+.title--20 {
+    font-size: 17px;
+    font-weight: 500;
+}
+
+.disabled {
+    opacity: 0.4;
+}

--- a/options/options.html
+++ b/options/options.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<link rel="stylesheet" href="options.css" type="text/css">
+	</head>
+	<body>
+		<h1 class="title--20">Preferences</h1>
+		<form>
+			<div class="browser-style">
+				<input type="checkbox" id="redirect-reddit" name="redirect" />
+				<label for="redirect-reddit">Redirect <a class="external-link" href="https://www.reddit.com" target="_blank">reddit.com</a> links to <a class="external-link" href="https://old.reddit.com" target="_blank">old.reddit.com</a>.</label>
+				<p class="helper">Ensure that the plain version of Reddit is loaded over the new redesign.</p>
+				</div>
+			</div>
+		</form>
+		<script src="options.js"></script>
+	</body>
+</html>

--- a/options/options.js
+++ b/options/options.js
@@ -1,0 +1,38 @@
+"use strict";
+
+function saveOptions(ev) {
+    const cb = ev.target;
+
+    // disable checkbox before storage
+    toggleForm(true, cb.form);
+
+    // save storage
+    const obj = {};
+    obj[cb.name] = cb.checked;
+    const cbPromise = browser.storage.local.set(obj)
+        .then(onSuccess, onError);
+
+    // enable checkbox
+    setTimeout(() => { toggleForm(false, cb.form); }, 700);
+}
+
+function onError(error) {
+    console.error(error);
+}
+
+function onSuccess(result) {
+    browser.storage.local.get().then((obj) => { console.log(obj); }, onError);
+}
+
+function toggleForm(disabled, form) {
+    form.className = disabled === true ? 'disabled' : '';
+    for (let i = 0; i < form.elements.length; i++) {
+        form.elements[i].disabled = disabled;
+    }
+}
+
+(function () {
+    // checkbox event listener
+    const redirectCb = document.getElementById('redirect-reddit');
+    redirectCb.addEventListener('change', saveOptions);
+}());

--- a/options/options.js
+++ b/options/options.js
@@ -58,7 +58,11 @@ function toggleForm(disabled, form) {
 }
 
 (function () {
-    // checkbox event listener
+    // register checkbox event listener
     const redirectCb = document.getElementById('redirect-reddit');
     redirectCb.addEventListener('change', saveOptions);
+
+    // fill checkbox with value from storage, default to false
+    browser.storage.local.get({ redirect: false })
+        .then((obj) => { redirectCb.checked = obj.redirect; }, onError);
 }());


### PR DESCRIPTION
Reddit's new redesign does not always work well on mobile devices, so this PR adds functionality to allow the user to redirect Reddit to its old version at https://old.reddit.com.

Resolves #1 