### PR TITLE
Fix error due to strict mode, and minor changes

### DIFF
--- a/background.js
+++ b/background.js
@@ -24,7 +24,7 @@ function setCookie() {
     const getCookieStores = browser.cookies.getAllCookieStores();
     getCookieStores.then((cookieStores) => {
         // set a cookie for each open cookie store (default, private, etc.)
-        for (store of cookieStores) {
+        for (const store of cookieStores) {
             noMobileCookie.storeId = store.id;
             const promise = browser.cookies.set(noMobileCookie);
             promise.then(onSuccess, onError);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "No mobile reddit",
-    "version": "1.1",
+    "version": "1.1.1",
     "description": "Prevents the mobile-friendly version of reddit from loading in the browser.",
     "icons": {
         "48": "no-mobile-reddit.svg",

--- a/options/options.js
+++ b/options/options.js
@@ -5,6 +5,10 @@ function saveOptions(ev) {
 
     // disable checkbox before storage
     toggleForm(true, cb.form);
+    // function to enable form after 700 ms
+    const timedEnable = () => {
+        setTimeout(() => { toggleForm(false, cb.form); }, 700);
+    };
 
     // save storage
     const obj = {};
@@ -14,13 +18,11 @@ function saveOptions(ev) {
     const promise = obj[cb.name]
         ? requestOptionalPermissions()
         : Promise.resolve();
-    promise.then(() => { return browser.storage.local.set(obj); }, onError)
-        .then(() => { return browser.storage.local.get(); }, onError)
-        .then((obj) => { console.log(obj); }, onError)
-        .finally(() => {
-            // enable checkbox
-            setTimeout(() => { toggleForm(false, cb.form); }, 700);
-        });
+    promise.then(() => { return browser.storage.local.set(obj); })
+        .then(() => { return browser.storage.local.get(); })
+        .then((obj) => { console.log(obj); })
+        .catch(onError)
+        .then(timedEnable, timedEnable); // ensure form is re-enabled
 }
 
 /**
@@ -39,7 +41,7 @@ function requestOptionalPermissions() {
             result
                 ? console.log('Permissions granted')
                 : console.error('Permissions denied');
-        }, onError);
+        }).catch(onError);
 }
 
 function onError(error) {
@@ -64,5 +66,6 @@ function toggleForm(disabled, form) {
 
     // fill checkbox with value from storage, default to false
     browser.storage.local.get({ redirect: false })
-        .then((obj) => { redirectCb.checked = obj.redirect; }, onError);
+        .then((obj) => { redirectCb.checked = obj.redirect; })
+        .catch(onError);
 }());


### PR DESCRIPTION
* Fixed undeclared variable error not working in strict mode
  * cookie wasn't setting due to undeclared variable
* Fixed promise error catching
  * Errors from code within `then` block were not being written to console
* Improved fulfillment of multiple promises at once in setCookies
  * Used `Promise.all` for more proper handling of multiple promises
* Replace Promise.finally with .then for better compatibility
  * `.finally` needs FF v58, but `.then` only needs v29, and some users are using less than v58